### PR TITLE
Bugfix/pandas warnings

### DIFF
--- a/neoantigen.py
+++ b/neoantigen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import print_function
 from six.moves.configparser import ConfigParser
 
@@ -337,7 +339,7 @@ def main():
             logger.info('Starting NetMHC 4.0...')
             #####
             # For netMHC-4 prediction, only predict on alleles for which data exists
-            netmhc_alleles = list(pd.read_csv(netmhc4_alleleslist, header=None, usecols=[0])[0], sep='\t')
+            netmhc_alleles = list(pd.read_csv(netmhc4_alleleslist, header=None, usecols=[0], sep='\t')[0])
             alleles_for_prediction = list(set(netmhc_alleles) & set([x.replace(':', '') for x in hla_alleles]))
             logger.info('Only predicting on the following HLA-alleles: ' + ','.join(sorted(set(alleles_for_prediction))))
 


### PR DESCRIPTION
This is meant to fix two warnings in pandas:

* ` FutureWarning: read_table is deprecated, use read_csv instead, passing sep='\t'. DONE`
* `FutureWarning: from_items is deprecated. Please use DataFrame.from_dict(dict(items), ...) instead. DataFrame.from_dict(OrderedDict(items)) may be used to preserve the key order.`

Here were the full warnings from a pipeline run:

```
/usr/local/bin/neoantigen/neoantigen.py:247: FutureWarning: read_table is deprecated, use read_csv instead, passing sep='\t'. DONE
  maf_df = pd.read_table(maf_file, comment='#', low_memory=False, header=0)
/usr/local/bin/neoantigen/neoantigen.py:339: FutureWarning: read_table is deprecated, use read_csv instead, passing sep='\t'. DONE
  netmhc_alleles = list(pd.read_table(netmhc4_alleleslist, header=None, usecols=[0])[0])
/usr/local/bin/neoantigen/neoantigen.py:391: FutureWarning: read_table is deprecated, use read_csv instead, passing sep='\t'. DONE
  np_df = pd.read_table(combined_output).drop_duplicates()
/usr/local/bin/neoantigen/neoantigen.py:459: FutureWarning: from_items is deprecated. Please use DataFrame.from_dict(dict(items), ...) instead. DataFrame.from_dict(OrderedDict(items)) may be used to preserve the key order.
  maf_output_df = pd.DataFrame.from_items([(s.name, s) for s in maf_output]).T
/usr/local/bin/neoantigen/neoantigen.py:462: FutureWarning: from_items is deprecated. Please use DataFrame.from_dict(dict(items), ...) instead. DataFrame.from_dict(OrderedDict(items)) may be used to preserve the key order.
  predictions_output_df = pd.DataFrame.from_items([(s.name, s) for s in predictions_output]).T
```

The following should fix these. I'll slack you three the data to double-check. 